### PR TITLE
Updated elgohr/Publish-Docker-Github-Action to a supported version (v5)

### DIFF
--- a/.github/workflows/docker_publish.yaml
+++ b/.github/workflows/docker_publish.yaml
@@ -9,7 +9,7 @@ jobs:
         runs-on: ubuntu-latest
         steps:
             - uses: actions/checkout@master
-            - uses: elgohr/Publish-Docker-Github-Action@master
+            - uses: elgohr/Publish-Docker-Github-Action@v5
               with:
                   name: wujingtao/cheap-db
                   username: 601595686@qq.com


### PR DESCRIPTION
elgohr/Publish-Docker-Github-Action@master is not supported anymore